### PR TITLE
feat: add TagSlice method template to get a slice of tag

### DIFF
--- a/internal/gtag/template.go
+++ b/internal/gtag/template.go
@@ -77,11 +77,33 @@ func (*{{$type}}) Tags(tag string, convert ...func(string) string) {{$type}}Tags
 	}
 }
 
+// TagSlice return specified tag slice of {{$type}}
+func (*{{$type}}) TagSlice(tag string, convert ...func(string) string) []string {
+	conv := func(in string) string { return strings.TrimSpace(strings.Split(in, ",")[0]) }
+	if len(convert) > 0 {
+		conv = convert[0]
+	}
+	if conv == nil {
+		conv = func(in string) string { return in }
+	}
+	return []string{
+{{- range .Fields}}
+		conv(tagOf{{$type}}{{.Name}}.Get(tag)),
+{{- end}}
+	}
+}
+
 {{range $tags}}
 // Tags{{.Name}} is alias of Tags("{{.Value}}")
 func (*{{$type}}) Tags{{.Name}}() {{$type}}Tags {
 	var v *{{$type}}
 	return v.Tags("{{.Value}}")
+}
+
+// TagSlice{{.Name}} is alias of TagSlice("{{.Value}}")
+func (*{{$type}}) TagSlice{{.Name}}() []string {
+	var v *{{$type}}
+	return v.TagSlice("{{.Value}}")
 }
 
 {{end}}

--- a/internal/gtag/template_test.go
+++ b/internal/gtag/template_test.go
@@ -97,6 +97,21 @@ func (*test) Tags(tag string, convert ...func(string) string) testTags {
 	}
 }
 
+// TagSlice return specified tag slice of test
+func (*test) TagSlice(tag string, convert ...func(string) string) []string {
+	conv := func(in string) string { return strings.TrimSpace(strings.Split(in, ",")[0]) }
+	if len(convert) > 0 {
+		conv = convert[0]
+	}
+	if conv == nil {
+		conv = func(in string) string { return in }
+	}
+	return []string{
+		conv(tagOftestA.Get(tag)),
+		conv(tagOftestb.Get(tag)),
+	}
+}
+
 
 // TagsJson is alias of Tags("json")
 func (*test) TagsJson() testTags {
@@ -104,11 +119,23 @@ func (*test) TagsJson() testTags {
 	return v.Tags("json")
 }
 
+// TagSliceJson is alias of TagSlice("json")
+func (*test) TagSliceJson() []string {
+	var v *test
+	return v.TagSlice("json")
+}
+
 
 // TagsBson is alias of Tags("bson")
 func (*test) TagsBson() testTags {
 	var v *test
 	return v.Tags("bson")
+}
+
+// TagSliceBson is alias of TagSlice("bson")
+func (*test) TagSliceBson() []string {
+	var v *test
+	return v.TagSlice("bson")
 }
 
 


### PR DESCRIPTION
I am working with a workflow engine, which has a config defination like ansible, where I'm unmarshal the config like this

```yml
- name: Some job to do
  variables:
    OS: linux
    ARCH: arm64
  // a module type that will descide which struct to unmarsha
  modules.build:
     binary: go
     // ... other keys
```

```go
type Pipe struct {
    Name string `yaml:"name"`
    Variables map[string]string `yaml:"variables"`
    Type  string
    module ModuleInterface
}

func (p *Pipe) UnmarshalYAML(unmarshal func(any) error) error {
    // ...    
    var v map[string]any
    if err := unmarshal(&v); err != nil {
        return err
    }

    for _, i := range p.TagSliceYaml() {
        delete(v, i)
    }

    switch len(v) {
    case 0:
        return fmt.Errorf("no vaild module")
    case 1:
    default:
        return fmt.Errorf("with %d modules: %v", len(v), v)
    }

    var module string
    var config any
    for k, v := range v {
        module, config = k, v
    }

    b, err := yaml.Marshal(config)
    if err != nil {
        return err
    }

    moduleInterface := GetMoudle(k)
    if err := yaml.Unmarshal(b, &moduleInterface); err != nil {
        return err
    }

    p.module  = moduleInterface 
    
    return nil
}
```

